### PR TITLE
cast expected remainingLength type to int32

### DIFF
--- a/header_test.go
+++ b/header_test.go
@@ -25,7 +25,7 @@ func TestMessageHeaderFields(t *testing.T) {
 
 	header.SetRemainingLength(33)
 
-	require.Equal(t, 33, header.RemainingLength())
+	require.Equal(t, int32(33), header.RemainingLength())
 
 	err := header.SetRemainingLength(268435456)
 


### PR DESCRIPTION
I ran `go test` with go1.5 darwin/amd64.
then:

```
--- FAIL: TestMessageHeaderFields (0.00s)
        Error Trace:    header_test.go:28
        Error:      Not equal: 33 (expected)
                    != 33 (actual)

FAIL
```

In `require.Equal(t, 33, header.RemainingLength())`, 33 is int by via interface{}.
But type of returning value of header.RemainingLength() is int32.

https://play.golang.org/p/LA9gpt17V1
